### PR TITLE
allow image sharing from other apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/jpeg" />
+            </intent-filter>
         </activity>
 
         <provider
@@ -38,6 +44,7 @@
             android:name=".DecodingActivity"
             android:screenOrientation="portrait">
         </activity>
+
     </application>
 
 </manifest>


### PR DESCRIPTION
This allows other apps to share data of type image/jpeg with the BeeTag app. This removes the necessity to use a third-party file explorer to move pictures to the Pictures/Beetags folder in order to use them in the app.
Note that the file modification date is not kept intact.

Please check if the changes are sensible.